### PR TITLE
Hot Fix 0.11.2

### DIFF
--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -3,7 +3,7 @@ version : '3'
 services:
 ### 1 Web Front End Container
   openrmf-web:
-    image: cingulara/openrmf-web:0.11.1
+    image: cingulara/openrmf-web:0.11.2
     ports:
       - 8080:80
     depends_on:
@@ -84,7 +84,7 @@ services:
       - openrmf
 
   openrmfapi-read:
-    image: cingulara/openrmf-api-read:0.11.1
+    image: cingulara/openrmf-api-read:0.11.2
     ports:
       - 8084:8080
     env_file: .env

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - openrmf
 
   openrmfapi-template:
-    image: cingulara/openrmf-api-template:0.11.1
+    image: cingulara/openrmf-api-template:0.11.2
     ports:
       - 8088:8080
     env_file: .env
@@ -301,6 +301,9 @@ services:
 
   prometheus:
     image: prom/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--web.enable-lifecycle'
     restart: always
     ports:
       - 9090

--- a/scripts/edge/docker-compose.yml
+++ b/scripts/edge/docker-compose.yml
@@ -128,7 +128,7 @@ services:
       - MONGODB=openrmfaudit
       - NATSSERVERURL=nats://natsserver:4222
     networks:
-      - openrmf
+      - openrmf-dev
 
 ### 7 Messaging Containers
   openrmfmsg-score:
@@ -183,7 +183,7 @@ services:
       - templatedb
       - natsserver
     networks:
-      - openrmf
+      - openrmf-dev
 
   openrmfmsg-system:
     image: cingulara/openrmf-msg-system
@@ -195,7 +195,7 @@ services:
       - checklistdb
       - natsserver
     networks:
-      - openrmf
+      - openrmf-dev
 
   openrmfmsg-audit:
     image: cingulara/openrmf-msg-audit
@@ -207,7 +207,7 @@ services:
       - checklistdb
       - natsserver
     networks:
-      - openrmf
+      - openrmf-dev
 
 ### 4 MongoDB Containers
   checklistdb:
@@ -268,7 +268,7 @@ services:
       - audit-data-volume:/data/db
       - ../initializeAudit.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
     networks:
-      - openrmf
+      - openrmf-dev
 
 ### NATS messaging container (internal)
   natsserver: 

--- a/scripts/edge/docker-compose.yml
+++ b/scripts/edge/docker-compose.yml
@@ -293,6 +293,9 @@ services:
 
   prometheus:
     image: prom/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--web.enable-lifecycle'
     restart: always
     ports:
       - 9090

--- a/scripts/local/docker-compose.yml
+++ b/scripts/local/docker-compose.yml
@@ -31,6 +31,9 @@ services:
 
   prometheus:
     image: prom/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--web.enable-lifecycle'
     restart: always
     ports:
       - 9090:9090


### PR DESCRIPTION
Fix:  CCI references on the checklist page, report, and export of checklists not showing between version 2.8.1 and 2.9.x of the DISA Java Viewer because of additional fields.