### PR TITLE
Fix port. Fix HEREDOC. Set CID on re-run. Issues #157, 158, 159

### DIFF
--- a/scripts/keycloak/setup-realm-linux.sh
+++ b/scripts/keycloak/setup-realm-linux.sh
@@ -1,49 +1,105 @@
-  echo "Enter the IP of the local Keycloak server (runs on port 9001):"
-  read keyip #>> $pathtohome/openrmf-Install.log
+#!/bin/bash
 
-  echo "Enter the Name of the first OpenRMF Administrator account:"
-  read openuser
+type jq > /dev/null
+if [ $? != 0 ]; then
+  echo "Please install jq from https://stedolan.github.io/jq/."
+  echo "  jq is needed to parse JSON."
+  exit
+fi
 
-  ##BEGIN Locate Keycloak Container ID
-    echo "Discovering local Keycloak Docker Container..."
-    keycontainer="$(sudo docker ps | grep "jboss/keycloak:" | awk '{ print $1 }')"
-    echo "$keycontainer"
-  ##END Locate Keycloak Container ID
+#
+# I find a mixture of sudo and non-sudo, to be a source of bugs. So I've
+# added a sudo check and removed sudo from the command below this point.
+#
 
-  ##BEGIN Authenticate to Keycloak server
-    echo "Authenticating to Keycloak Master Realm..."
-    sudo docker exec $keycontainer /opt/jboss/keycloak/bin/kcadm.sh config credentials --server http://$keyip:9001/auth --realm master --user admin --password admin
-  ##END Authenticate to Keycloak server
+NC="\e[0m"
+RED="\e[0;31m"
+CYAN="\e[0;36m"
+BOLD=$(tput bold)
+NORMAL=$(tput sgr0)
 
-  ##BEGIN Create Realm
-    echo "Creating the Realm..."
-    sudo docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create realms -s realm=openrmf -s enabled=true
-  ##END Create Realm
+if [ "$EUID" -ne 0 ]; then
+  echo -e "${BOLD}${RED}You are not running this script as root.${NC}${NORMAL}"
+  echo -e "$CYAN"
+  echo "  This script uses docker which frequently requires sudo to run."
+  echo "  Therefore, please either edit this script to remove this check"
+  echo "  or run the script using sudo."
+  echo -e "$NC"
+  exit
+fi
 
-  ##BEGIN Create Password Policy
-    echo "Creating the Password Policy (12 digits, 2 upper, 2 lower, 2 number, 2 special character)..."
-    sudo docker exec $keycontainer /opt/jboss/keycloak/bin/kcadm.sh update realms/openrmf -s 'passwordPolicy="hashIterations and specialChars and upperCase and digits and notUsername and length"'
-  ##END Create Password Policy 
+echo
+echo -e "${BOLD}Keycloak Server IP${NORMAL}"
+echo -e "$CYAN"
+echo "  The Keycloak container is running in a docker container. It is"
+echo "  probably called 'keycloak_keycloak_1' or something similiar."
+echo
+echo "  In 'docker ps' it shows as listening on port 9001."
+echo -e "$NC"
+read -p "  What is it's IP address? " keyip #>> $pathtohome/openrmf-Install.log
 
-  ##BEGIN Create Roles
-    echo "Creating the 5 OpenRMF Roles..."
-    sudo docker exec $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create roles -r openrmf -s name=Administrator -s 'description=Admin role for openrmf'
-    sudo docker exec $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create roles -r openrmf -s name=Assessor -s 'description=Assessor Role for openrmf'
-    sudo docker exec $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create roles -r openrmf -s name=Download -s 'description=Download Role to pull down XLSX and CKL files in openrmf'
-    sudo docker exec $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create roles -r openrmf -s name=Editor -s 'description=Editor role for openrmf'
-    sudo docker exec $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create roles -r openrmf -s name=Reader -s 'description=Read-Only role for openrmf'
-  ##END Create Roles
+echo
+echo -e "${BOLD}OpenRMF Administrator account${NORMAL}"
+echo -e "$CYAN"
+echo "  Note that Keycloak has its own administrator account called 'admin'."
+echo "  Consider using 'rmf-admin' or anything but 'admin' itself."
+echo -e "$NC"
+read -p "  Enter the Name of the first OpenRMF Administrator account: " openuser
 
-  ##BEGIN Create Client 
-    echo "Creating the Keycloak Client..."
-    cid=$(sudo docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create clients -r openrmf -s enabled=true -s clientId=openrmf -s publicClient=true -s 'description=openrmf login for Web and APIs' -s 'redirectUris=["http://'$keyip':8080/*"]' -s 'webOrigins=["*"]' -i)
-    echo "$cid"
-  ##END Create Client
+#
+# NOTE: It is expected that only one keyclock container is running.
+#
 
-  ##BEGIN Create Protocol Mapper
-    echo "Creating the Client Protocol Mapper..." 
-    sudo docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create \
-    clients/$cid/protocol-mappers/models \
+##BEGIN Locate Keycloak Container ID
+echo
+echo "Discovering local Keycloak Docker Container..."
+keycontainer="$(docker ps | grep "jboss/keycloak:" | awk '{ print $1 }')"
+echo "keycontainer: $keycontainer"
+##END Locate Keycloak Container ID
+
+##BEGIN Authenticate to Keycloak server
+echo
+echo "Authenticating to Keycloak Master Realm..."
+docker exec $keycontainer /opt/jboss/keycloak/bin/kcadm.sh config credentials --server http://$keyip:8080/auth --realm master --user admin --password admin
+##END Authenticate to Keycloak server
+
+##BEGIN Create Realm
+echo
+echo "Creating the Realm..."
+docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create realms -s realm=openrmf -s enabled=true
+##END Create Realm
+
+##BEGIN Create Password Policy
+echo
+echo "Creating the Password Policy (12 digits, 2 upper, 2 lower, 2 number, 2 special character)..."
+docker exec $keycontainer /opt/jboss/keycloak/bin/kcadm.sh update realms/openrmf -s 'passwordPolicy="hashIterations and specialChars and upperCase and digits and notUsername and length"'
+##END Create Password Policy
+
+##BEGIN Create Roles
+echo
+echo "Creating the 5 OpenRMF Roles..."
+docker exec $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create roles -r openrmf -s name=Administrator -s 'description=Admin role for openrmf'
+docker exec $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create roles -r openrmf -s name=Assessor -s 'description=Assessor Role for openrmf'
+docker exec $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create roles -r openrmf -s name=Download -s 'description=Download Role to pull down XLSX and CKL files in openrmf'
+docker exec $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create roles -r openrmf -s name=Editor -s 'description=Editor role for openrmf'
+docker exec $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create roles -r openrmf -s name=Reader -s 'description=Read-Only role for openrmf'
+##END Create Roles
+
+##BEGIN Create Client
+echo
+echo "Creating client"
+cid=$(docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh get clients -r openrmf -q clientId=openrmf 2>/dev/null | jq --raw-output '.[0].id')
+if [ -z $cid ]; then
+  cid=$(docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create clients -r openrmf -s enabled=true -s clientId=openrmf -s publicClient=true -s 'description=openrmf login for Web and APIs' -s 'redirectUris=["http://'$keyip':8080/*"]' -s 'webOrigins=["*"]' -i)
+fi
+echo "Client ID: $cid"
+##END Create Client
+
+##BEGIN Create Protocol Mapper
+echo
+echo "Creating the Client Protocol Mapper..."
+docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create \
+  clients/$cid/protocol-mappers/models \
     -r openrmf \
     -s name=roles \
     -s protocol=openid-connect \
@@ -54,23 +110,27 @@
     -s 'config."multivalued"=true' \
     -s 'config."userinfo.token.claim"=true' \
     -s 'config."access.token.claim"=true'
-  ##END Create Protocol Mapper
+##END Create Protocol Mapper
 
-  ##BEGIN Create first admin
-    echo "Creating the first OpenRMF Administrator account..." 
-    sudo docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create users -r openrmf -s username=$openuser -s enabled=true -s 'requiredActions=["UPDATE_PASSWORD"]'
-    sudo docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh add-roles --uusername $openuser --rolename Administrator -r openrmf
-    sudo docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh add-roles --uusername $openuser --rolename Assessor -r openrmf
-    sudo docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh add-roles --uusername $openuser --rolename Download -r openrmf
-    sudo docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh add-roles --uusername $openuser --rolename Editor -r openrmf
-    sudo docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh add-roles --uusername $openuser --rolename Reader -r openrmf
-  ##END Create first openrmf admin
+##BEGIN Create first admin
+echo
+echo "Creating the first OpenRMF Administrator account..."
+docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create users -r openrmf -s username=$openuser -s enabled=true -s 'requiredActions=["UPDATE_PASSWORD"]'
+docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh add-roles --uusername $openuser --rolename Administrator -r openrmf
+docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh add-roles --uusername $openuser --rolename Assessor -r openrmf
+docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh add-roles --uusername $openuser --rolename Download -r openrmf
+docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh add-roles --uusername $openuser --rolename Editor -r openrmf
+docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh add-roles --uusername $openuser --rolename Reader -r openrmf
+##END Create first openrmf admin
 
-  ##BEGIN Password Policy of 2/2/2/2 12 characters and not the same as the username
-    sudo docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh update realms/openrmf -s 'passwordPolicy="hashIterations(27500) and specialChars(2) and upperCase(2) and digits(2) and notUsername(undefined) and length(12)"'
-  ##END Password Policy
+##BEGIN Password Policy of 2/2/2/2 12 characters and not the same as the username
+docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh update realms/openrmf -s 'passwordPolicy="hashIterations(27500) and specialChars(2) and upperCase(2) and digits(2) and notUsername(undefined) and length(12)"'
+##END Password Policy
 
-  ##BEGIN Add Reader Role to Default Realm Roles
-   echo "Last step - Adding Reader Role to Default Realm Roles..."
-     sudo docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh update realms/openrmf -f - << echo {"defaultRoles" :["offline_access", "uma_authorization", "Reader"]} 
-  ##END Add Reader Role to Default Realm Roles
+##BEGIN Add Reader Role to Default Realm Roles
+echo
+echo "Last step - Adding Reader Role to Default Realm Roles..."
+sudo docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh update realms/openrmf -f - <<EOF
+{"defaultRoles" :["offline_access", "uma_authorization", "Reader"]}
+EOF
+##END Add Reader Role to Default Realm Roles


### PR DESCRIPTION
I updated the `setup-realm-linux.sh` script to resolve (hopefully issue #157, #158, and #159. And I added some fancy formatting to messages. Also, added a dependency on the jq command with a check at the top of the script.

#157 - The port was changed to 8080 because the command using it is run inside the context of the container. I also think that the hostname should always be localhost since the command is run inside of the container?

#158 - I used a simple HEREDOC using multiple lines.

#159 - I get the 'get clients' command to get the CID if one exists. Then CID can be safely used in the next step of creating the protocol mapper.
