### PR TITLE
Updates for Linux KC realm script

### DIFF
--- a/scripts/keycloak/setup-realm-linux.sh
+++ b/scripts/keycloak/setup-realm-linux.sh
@@ -6,43 +6,43 @@
 
   ##BEGIN Locate Keycloak Container ID
     echo "Discovering local Keycloak Docker Container..."
-    keycontainer="$(sudo docker ps | grep "jboss/keycloak:" | awk '{ print $1 }')"
+    keycontainer="$( docker ps | grep "jboss/keycloak:" | awk '{ print $1 }')"
     echo "$keycontainer"
   ##END Locate Keycloak Container ID
 
   ##BEGIN Authenticate to Keycloak server
     echo "Authenticating to Keycloak Master Realm..."
-    sudo docker exec $keycontainer /opt/jboss/keycloak/bin/kcadm.sh config credentials --server http://$keyip:9001/auth --realm master --user admin --password admin
+     docker exec $keycontainer /opt/jboss/keycloak/bin/kcadm.sh config credentials --server http://localhost:8080/auth --realm master --user admin --password admin
   ##END Authenticate to Keycloak server
 
   ##BEGIN Create Realm
     echo "Creating the Realm..."
-    sudo docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create realms -s realm=openrmf -s enabled=true
+     docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create realms -s realm=openrmf -s enabled=true
   ##END Create Realm
 
   ##BEGIN Create Password Policy
     echo "Creating the Password Policy (12 digits, 2 upper, 2 lower, 2 number, 2 special character)..."
-    sudo docker exec $keycontainer /opt/jboss/keycloak/bin/kcadm.sh update realms/openrmf -s 'passwordPolicy="hashIterations and specialChars and upperCase and digits and notUsername and length"'
+     docker exec $keycontainer /opt/jboss/keycloak/bin/kcadm.sh update realms/openrmf -s 'passwordPolicy="hashIterations and specialChars and upperCase and digits and notUsername and length"'
   ##END Create Password Policy 
 
   ##BEGIN Create Roles
     echo "Creating the 5 OpenRMF Roles..."
-    sudo docker exec $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create roles -r openrmf -s name=Administrator -s 'description=Admin role for openrmf'
-    sudo docker exec $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create roles -r openrmf -s name=Assessor -s 'description=Assessor Role for openrmf'
-    sudo docker exec $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create roles -r openrmf -s name=Download -s 'description=Download Role to pull down XLSX and CKL files in openrmf'
-    sudo docker exec $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create roles -r openrmf -s name=Editor -s 'description=Editor role for openrmf'
-    sudo docker exec $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create roles -r openrmf -s name=Reader -s 'description=Read-Only role for openrmf'
+     docker exec $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create roles -r openrmf -s name=Administrator -s 'description=Admin role for openrmf'
+     docker exec $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create roles -r openrmf -s name=Assessor -s 'description=Assessor Role for openrmf'
+     docker exec $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create roles -r openrmf -s name=Download -s 'description=Download Role to pull down XLSX and CKL files in openrmf'
+     docker exec $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create roles -r openrmf -s name=Editor -s 'description=Editor role for openrmf'
+     docker exec $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create roles -r openrmf -s name=Reader -s 'description=Read-Only role for openrmf'
   ##END Create Roles
 
   ##BEGIN Create Client 
     echo "Creating the Keycloak Client..."
-    cid=$(sudo docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create clients -r openrmf -s enabled=true -s clientId=openrmf -s publicClient=true -s 'description=openrmf login for Web and APIs' -s 'redirectUris=["http://'$keyip':8080/*"]' -s 'webOrigins=["*"]' -i)
+    cid=$( docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create clients -r openrmf -s enabled=true -s clientId=openrmf -s publicClient=true -s 'description=openrmf login for Web and APIs' -s 'redirectUris=["http://'$keyip':8080/*"]' -s 'webOrigins=["*"]' -i)
     echo "$cid"
   ##END Create Client
 
   ##BEGIN Create Protocol Mapper
     echo "Creating the Client Protocol Mapper..." 
-    sudo docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create \
+     docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create \
     clients/$cid/protocol-mappers/models \
     -r openrmf \
     -s name=roles \
@@ -58,19 +58,19 @@
 
   ##BEGIN Create first admin
     echo "Creating the first OpenRMF Administrator account..." 
-    sudo docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create users -r openrmf -s username=$openuser -s enabled=true -s 'requiredActions=["UPDATE_PASSWORD"]'
-    sudo docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh add-roles --uusername $openuser --rolename Administrator -r openrmf
-    sudo docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh add-roles --uusername $openuser --rolename Assessor -r openrmf
-    sudo docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh add-roles --uusername $openuser --rolename Download -r openrmf
-    sudo docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh add-roles --uusername $openuser --rolename Editor -r openrmf
-    sudo docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh add-roles --uusername $openuser --rolename Reader -r openrmf
+     docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh create users -r openrmf -s username=$openuser -s enabled=true -s 'requiredActions=["UPDATE_PASSWORD"]'
+     docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh add-roles --uusername $openuser --rolename Administrator -r openrmf
+     docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh add-roles --uusername $openuser --rolename Assessor -r openrmf
+     docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh add-roles --uusername $openuser --rolename Download -r openrmf
+     docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh add-roles --uusername $openuser --rolename Editor -r openrmf
+     docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh add-roles --uusername $openuser --rolename Reader -r openrmf
   ##END Create first openrmf admin
 
   ##BEGIN Password Policy of 2/2/2/2 12 characters and not the same as the username
-    sudo docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh update realms/openrmf -s 'passwordPolicy="hashIterations(27500) and specialChars(2) and upperCase(2) and digits(2) and notUsername(undefined) and length(12)"'
+     docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh update realms/openrmf -s 'passwordPolicy="hashIterations(27500) and specialChars(2) and upperCase(2) and digits(2) and notUsername(undefined) and length(12)"'
   ##END Password Policy
 
   ##BEGIN Add Reader Role to Default Realm Roles
    echo "Last step - Adding Reader Role to Default Realm Roles..."
-     sudo docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh update realms/openrmf -f - << echo {"defaultRoles" :["offline_access", "uma_authorization", "Reader"]} 
+      echo '{"defaultRoles" :["offline_access", "uma_authorization", "Reader"]}' | docker exec -i $keycontainer /opt/jboss/keycloak/bin/kcadm.sh update realms/openrmf -f -  
   ##END Add Reader Role to Default Realm Roles


### PR DESCRIPTION
This updates the setup-realm-linux.sh script in the following ways:

1) Hard codes the kcadm to communicate with the application running in container by pointing to localhost from within the container (line 15),

2) removes sudo from docker commands (requires the running user to have docker privs or to run the script under sudo),

3) fixes the echo redirect in line 75.