### PR TITLE
Fix link to auth.js in domainkeycloak.md

### DIFF
--- a/docs/domainkeycloak.md
+++ b/docs/domainkeycloak.md
@@ -43,4 +43,4 @@ var keycloak = Keycloak({
 10. You should see it go to your new URL for login. 
 11. As long as you set it up manually correctly you should be able to login, get your roles, redirect back to OpenRMF<sup>&reg;</sup> OSS and continue on!
 
-> Don't worry, if you mess it up just go back to the https://github.com/Cingulara/openrmf-web/blob/master/js/auth.js main file and copy/paste to start over. 
+> Don't worry, if you mess it up just go back to the https://github.com/Cingulara/openrmf-web/blob/master/wwwroot/js/auth.js main file and copy/paste to start over. 


### PR DESCRIPTION
It looks like auth.js lives in wwwroot/js/ now, after a big restructuring in 2024: https://github.com/Cingulara/openrmf-web/commit/d52a0c0021010ada30a03ff5392014bb5317eaad